### PR TITLE
Add Ngrok + Wordpress + MySQL template

### DIFF
--- a/ngrok_wp_mysql_andrewmunsell.pmx
+++ b/ngrok_wp_mysql_andrewmunsell.pmx
@@ -1,0 +1,61 @@
+---
+name: Ngrok + Wordpress + MySQL
+description: In addition to hosting Wordpress and MySQL in separate containers, Ngrok
+  has been added into the mix to allow for external access to the Wordpress website
+  by anyone on the internet.
+keywords: wordpress, ngrok, mysql
+type: Wordpress
+documentation: "Wordpress with MySQL\r\n============================\r\nThe alias
+  for the link between Wordpress and MySQL needs to be _DB_1_. If this is changed,
+  the template will not work.\r\n\r\nAlso, the password can be changed, but the environmental
+  variables need to be changed on both services.\r\n\r\nBecause this template uses
+  Ngrok, you do not have to setup any port forwarding rules in VirtualBox or otherwise.
+  To view your new Wordpress installation, simply wait until all of the containers
+  are done launching. As the Ngrok container is launching, you should see a URL output
+  into the console that looks similar to this:\r\n\r\nhttps://h47fhw87h.ngrok.com\r\n\r\nSimply
+  copy the URL and paste it into your browser to see Wordpress running inside of Panamax.
+  You can also configure Ngrok in the following ways using the specified environmental
+  variables. Simply set the following variables in the Ngrok container inside of your
+  Panamax UI to change the desired behavior of the Ngrok tunnel:\r\n\r\n- `NGROK_AUTH`
+  - Authentication key for your [Ngrok account](https://ngrok.com). This is needed
+  for custom subdomains, custom domains, and HTTP authentication\r\n- `NGROK_SUBDOMAIN`
+  - Name of the custom subdomain to use for your tunnel. You must also provide the
+  authentication token\r\n- `NGROK_DOMAIN` - Paying Ngrok customers can specify a
+  custom domain. Only one subdomain or domain can be specified, with the domain taking
+  priority.\r\n- `NGROK_USERNAME` - Username to use for HTTP authentication on the
+  tunnel. You must also specify an authentication token\r\n- `NGROK_PASSWORD` - Password
+  to use for HTTP authentication on the tunnel. You must also specify an authentication
+  token"
+images:
+- name: DB
+  source: centurylink/mysql:5.5
+  category: DB Tier
+  type: mysql
+  ports:
+  - host_port: 3306
+    container_port: 3306
+  environment:
+  - variable: MYSQL_ROOT_PASSWORD
+    value: pass@word01
+- name: WP
+  source: centurylink/wordpress:3.9.1
+  category: Web Tier
+  type: wordpress
+  ports:
+  - host_port: 8080
+    container_port: 80
+  links:
+  - service: DB
+    alias: DB_1
+  environment:
+  - variable: DB_PASSWORD
+    value: pass@word01
+  - variable: DB_NAME
+    value: wordpress
+- name: Ngrok
+  source: wizardapps/ngrok:latest
+  category: Proxy Tier
+  type: Default
+  links:
+  - service: WP
+    alias: APP


### PR DESCRIPTION
Add the Ngrok + Wordpress + MySQL template.

Unlike the default template, this one provides zero-configuration access to the Wordpress container through Ngrok. Simply watch the logs for the Ngrok URL and then copy-and-paste it into your browser to see your Wordpress instance running in Panamax.

Other configuration options are also available, including custom subdomains, domains, and HTTP authentication, all through configuring Ngrok with environmental variables.
