### PR TITLE
Atlassian JIRA: fixed vbox port mapping in documentation

### DIFF
--- a/atlassian-jira.pmx
+++ b/atlassian-jira.pmx
@@ -9,7 +9,7 @@ documentation: |
 
   In order to access JIRA after running you will need to setup a port forwarding rule. To view the GUI after launching the template, map your local host machine to port 9021. If using Virtual Box, use the following command in your terminal to create the port forwarding rule:
 
-  `VBoxManage controlvm panamax-vm natpf1 jira,tcp,,8080,,9021`
+  `VBoxManage controlvm panamax-vm natpf1 jira,tcp,,8080,,9020`
 
   Setup
   -----


### PR DESCRIPTION
I just realized I had a typo in my documentation for port mapping to the virtual box hosting Panamax.
