### PR TITLE
Ipython notebook with numpy, pandas and psycopg2

### DIFF
--- a/ipython_notebook.pmx
+++ b/ipython_notebook.pmx
@@ -8,7 +8,7 @@ documentation: |-
 
  It has been set to use port 9999
 
- It uses a self-signed certificate and sets the default password to panamax.
+ It uses a self-signed certificate and sets the default password to `panamax`.
 
  You can set PASSWORD environment variable in the applications management screen.
 


### PR DESCRIPTION
The IPython notebook modified slightly to play well with panamax.
It has been set to use port 9999
It uses a self-signed certificate and sets the default password to panamax.
You can set PASSWORD environment variable in the applications management screen.
You will need to set the following rule to forward to the panamax-vm.
VBoxManage controlvm panamax-vm natpf1 ipython,tcp,,9999,,9999
This notebook includes a few libraries not found found in the default ipython/notebook image.
You have: numpy python matrix and linear algebra library. pandas a data analyis frame work psycopg2 postgresql database access
This should be enough to get you started on a basic python data analysis stack.
