### PR TITLE
PanaMage - Magento Community Edition on Docker

### DIFF
--- a/panamage.pmx
+++ b/panamage.pmx
@@ -1,19 +1,10 @@
 ---
 name: panamage
-description: this panamax template helps you setup a magento installation.
+description: this panamax template helps you setup a containerized infrastructure for running the magento e-commerce platform.
 keywords: magento, nginx, varnish, redis, php, mysql
 type: Magento
-documentation: |-
-  ##Application Name:
-
-  ##System Requirements:
-
-  ##Setup:
-
-  ##Post-Run Instructions:
-
-  ##Resources:
-
+documentation: |+
+*work-in-progress*
 images:
 - name: lb_nginx
   source: nginx:latest
@@ -73,7 +64,7 @@ images:
     container_path: '/usr/local/nginx/html'
   - host_path: '/var/panamax/confdata/web_nginx'
     container_path: "/etc/nginx"
-- name: app_php-fpm
+- name: app_phpfpm
   source: jprjr/ubuntu-php-fpm:latest
   category: APP
   type: Default
@@ -88,6 +79,8 @@ images:
     alias: web_nginx
   - service: db_mysql
     alias: db_mysql
+  - service: db_redis
+    alias: db_redis
   volumes:
   - host_path: '/var/panamax/confdata/app_phpfpm'
     container_path: '/etc/php5'


### PR DESCRIPTION
This template is a work-in-progress and at the time only outlines the proposed service layout for a full containerized magento setup. Most docker-based approaches on this wrap multiple services (like php + nginx) into one single container, whereas we strive to really split all parts into single ones and connect them wisely. 
We currently use a similar layout on multiple projects and build it with a comprehensive set of chef cookbooks. Our goal is to translate those cookbooks to docker containers, allowing to quickly replicate the whole stack without starting from scratch. Since a lot of "magic" is done inside the docker containers and panamax "only" should connect them, we have to focus on the bare containers first.
I submit this mainly to show there is movement in the community - the deadline for the contest was too hard here ;-) Since panamax is also not stable yet, I hope this template evolves as we move along.
